### PR TITLE
payton: enable MTP support

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -111,7 +111,7 @@ TW_EXTRA_LANGUAGES := true
 TARGET_RECOVERY_DEVICE_MODULES += android.hardware.boot@1.0
 TW_RECOVERY_ADDITIONAL_RELINK_FILES := ${OUT}/system/lib64/android.hardware.boot@1.0.so
 # MTP will not work until we update it to support ffs
-TW_EXCLUDE_MTP := true
+#TW_EXCLUDE_MTP := true
 
 # Debug flags
 #TWRP_INCLUDE_LOGCAT := true

--- a/recovery/root/fstab.qcom
+++ b/recovery/root/fstab.qcom
@@ -8,7 +8,7 @@
 #<src>                                   <mnt_point>        <type> <mnt_flags and options>                          <fs_mgr_flags>
 /dev/block/bootdevice/by-name/system     /                  ext4   ro,barrier=1,discard                             wait,slotselect
 /dev/block/bootdevice/by-name/userdata   /data              ext4   nobarrier,noatime,nosuid,nodev,discard,data=ordered,noauto_da_alloc  wait,check,formattable,fileencryption=ice
-/devices/soc/c084000.sdhci/mmc_host*     auto               auto   defaults                                         wait,voldmanaged=sdcard1:auto
+/devices/soc/c084000.sdhci/mmc_host*     auto               auto   defaults                                         wait,voldmanaged=sdcard1:auto,encryptable=userdata
 /dev/block/zram0                         none               swap   defaults                                         zramsize=536870912
 /dev/block/bootdevice/by-name/misc       /misc              emmc   defaults                                         defaults
 /dev/block/bootdevice/by-name/modem      /firmware          ext4   ro,nosuid,nodev                                  wait,slotselect

--- a/rootdir/root/fstab.qcom
+++ b/rootdir/root/fstab.qcom
@@ -8,7 +8,7 @@
 #<src>                                   <mnt_point>        <type> <mnt_flags and options>                          <fs_mgr_flags>
 /dev/block/bootdevice/by-name/system     /                  ext4   ro,barrier=1,discard                             wait,verify,slotselect
 /dev/block/bootdevice/by-name/userdata   /data              ext4   nobarrier,noatime,nosuid,nodev,discard,data=ordered,noauto_da_alloc	wait,check,formattable,fileencryption=ice:aes-256-cts,quota
-/devices/soc/c084000.sdhci/mmc_host*     auto               auto   defaults                                         wait,voldmanaged=sdcard1:auto
+/devices/soc/c084000.sdhci/mmc_host*     auto               auto   defaults                                         wait,voldmanaged=sdcard1:auto,encryptable=userdata
 /dev/block/zram0                         none               swap   defaults                                         zramsize=536870912
 /dev/block/bootdevice/by-name/misc       /misc              emmc   defaults                                         defaults
 /dev/block/bootdevice/by-name/modem      /firmware          ext4   ro,nosuid,nodev,context=u:object_r:firmware_file:s0 wait,slotselect

--- a/system.prop
+++ b/system.prop
@@ -1,1 +1,2 @@
 ro.display.series=Moto X4
+persist.sys.usb.config=mtp


### PR DESCRIPTION
Log of TWRP 3.2.3-0 built with these changes. 
[TWRP_LOG](https://del.dog/enaqimavij.sql)
[KERNEL_LOG](https://del.dog/egoredakum.htm)
Tested enable/disable MTP
Copied files to and from sdcard/external_sd over MTP
Copied files to and from sdcard/external_sd over ADB
